### PR TITLE
Digitalsig append sigbytes flevel min

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
+## Version 1.2.4
+
+🐛Fix the minimum feature level when writing bytes for a new `.sign` digital signature.
+
 ## Version 1.2.3
 
 🐛Properly remove the `structopt` dependency (from `Cargo.toml`). It is no longer being used, but must be removed from the list.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "clam-sigutil"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "change-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The ClamAV Team <clamav-bugs@external.cisco.com>"]
 edition = "2021"
 name = "clam-sigutil"
-version = "1.2.3"
+version = "1.2.4"
 
 [features]
 default = []

--- a/src/signature/digital_sig.rs
+++ b/src/signature/digital_sig.rs
@@ -87,7 +87,9 @@ impl AppendSigBytes for DigitalSig {
         match &self {
             DigitalSig::Pkcs7(pkcs7) => {
                 // write out the flevel_min and flevel_max
-                sb.write_all(b"220::")?;
+                sb.write_all(
+                    format!("{}::", Feature::DigitalSignaturePkcs7Pem.min_flevel()).as_bytes(),
+                )?;
 
                 // write out the signature format
                 sb.write_all(b"pkcs7-pem:")?;


### PR DESCRIPTION
- [Fix flevel when writing digital signature bytes](https://github.com/Cisco-Talos/clamav-signature-util/commit/9768dfc4e8f81d141a4f8f5cdee386ad22fe9e8a) 

  The min flevel for this feature was raised 230 when ClamAV 1.4 was
promoted to LTS.

  This commit generates the flevel when writing the signature, based
on the value in feature-level.txt

- [Bump version to 1.2.4](https://github.com/Cisco-Talos/clamav-signature-util/commit/fa535d561cd57160d38338e4ed22cd9145a6d6b2)

Note: this is needed in order to:
1. upgrade clamav to use clam_sigutil v1.2.3+ https://github.com/Cisco-Talos/clamav/pull/1489
2. create correct `.sign` signatures that have the min flevel 230.